### PR TITLE
SYS-3514: Make the Jenkins build work

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 dockerbuild {
 	gitUrl = "git@github.com:benetech/ServiceNet.git"
 	dockerFile = "src/main/docker/Dockerfile"
-	remoteRepository = "814633283276.dkr.ecr.us-east-1.amazonaws.com"
+	dockerRepository = "814633283276.dkr.ecr.us-east-1.amazonaws.com"
 	artifactName = "servicenet"
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 dockerbuild {
 	gitUrl = "git@github.com:benetech/ServiceNet.git"
-	dockerFile = "src/main/docker/Dockerfile"
+	dockerFile = "src/main/docker/Dockerfile-multistage"
 	dockerRepository = "814633283276.dkr.ecr.us-east-1.amazonaws.com"
 	artifactName = "servicenet"
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,9 @@
+import org.benetech.build.versioning.PomXmlVersioner
+
 dockerbuild {
 	gitUrl = "git@github.com:benetech/ServiceNet.git"
 	dockerFile = "src/main/docker/Dockerfile-multistage"
 	dockerRepository = "814633283276.dkr.ecr.us-east-1.amazonaws.com"
 	artifactName = "servicenet"
+	versioner = new PomXmlVersioner()
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,6 @@
+dockerbuild {
+	gitUrl = "git@github.com:benetech/ServiceNet.git"
+	dockerFile = "src/main/docker/Dockerfile"
+	remoteRepository = "814633283276.dkr.ecr.us-east-1.amazonaws.com"
+	artifactName = "servicenet"
+}

--- a/src/main/docker/Dockerfile-multistage
+++ b/src/main/docker/Dockerfile-multistage
@@ -1,0 +1,27 @@
+FROM openjdk:11 AS build
+
+RUN mkdir /build
+COPY / /build
+
+WORKDIR /build
+RUN ./mvnw clean package -Pprod
+
+FROM openjdk:11
+
+ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS \
+    JHIPSTER_SLEEP=0 \
+    JAVA_OPTS=""
+
+# Add a jhipster user to run our application so that it doesn't need to run as root
+RUN adduser --shell /bin/sh jhipster
+WORKDIR /home/jhipster
+
+COPY src/main/docker/entrypoint.sh entrypoint.sh
+RUN chmod 755 entrypoint.sh && chown jhipster:jhipster entrypoint.sh
+USER jhipster
+
+ENTRYPOINT ["./entrypoint.sh"]
+
+EXPOSE 8080
+
+COPY --from=build /build/target/*.war app.war


### PR DESCRIPTION
Build ServiceNet in Jenkins. Uses the new Jenkins Pipeline API (see https://bugs.benetech.org/browse/SYS-3514).

Creates a new Dockerfile-multistage which does not rely on anything other than Docker to build the images in the docker container. This reduced the complexity of needed dependencies on Jenkins since it appears we can only build Docker containers on the master.