### PR TITLE
#378: Fix size of fields

### DIFF
--- a/src/main/webapp/app/modules/conflicts/shared/components/service/eligibility-details.tsx
+++ b/src/main/webapp/app/modules/conflicts/shared/components/service/eligibility-details.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { IActivityRecord } from 'app/shared/model/activity-record.model';
 import { AdditionalDetails } from '../additional-details';
 import { IEligibility } from 'app/shared/model/eligibility.model';
-import { getTextField } from 'app/shared/util/single-record-view-utils';
+import { getTextAreaField } from 'app/shared/util/single-record-view-utils';
 
 export interface IEligibilityDetailsProp extends StateProps, DispatchProps {
   activity: IActivityRecord;
@@ -15,7 +15,7 @@ export interface IEligibilityDetailsProp extends StateProps, DispatchProps {
 export class EligibilityDetails extends React.Component<IEligibilityDetailsProp> {
   render() {
     const eligibility = this.props.eligibility ? this.props.eligibility : {};
-    const fields = [getTextField(eligibility, 'eligibility')];
+    const fields = [getTextAreaField(eligibility, 'eligibility')];
 
     return (
       <AdditionalDetails

--- a/src/main/webapp/app/modules/conflicts/shared/components/service/required-documents-details.tsx
+++ b/src/main/webapp/app/modules/conflicts/shared/components/service/required-documents-details.tsx
@@ -6,7 +6,7 @@ import { AdditionalDetails } from '../additional-details';
 import { IRequiredDocument } from 'app/shared/model/required-document.model';
 import { Translate } from 'react-jhipster';
 import { Badge } from 'reactstrap';
-import { getTextField } from 'app/shared/util/single-record-view-utils';
+import { getTextAreaField } from 'app/shared/util/single-record-view-utils';
 
 export interface IRequiredDocumentsDetailsProp extends StateProps, DispatchProps {
   activity: IActivityRecord;
@@ -17,7 +17,7 @@ export interface IRequiredDocumentsDetailsProp extends StateProps, DispatchProps
 export class RequiredDocumentsDetails extends React.Component<IRequiredDocumentsDetailsProp> {
   render() {
     const { docs } = this.props;
-    const fields = docs.map(document => getTextField(document, 'document'));
+    const fields = docs.map(document => getTextAreaField(document, 'document'));
 
     return fields.length > 0 ? (
       <AdditionalDetails

--- a/src/main/webapp/app/shared/util/single-record-view-utils.ts
+++ b/src/main/webapp/app/shared/util/single-record-view-utils.ts
@@ -3,3 +3,8 @@ export const getTextField = (object, fieldName) => ({
   fieldName,
   defaultValue: object[fieldName]
 });
+export const getTextAreaField = (object, fieldName) => ({
+  type: 'textarea',
+  fieldName,
+  defaultValue: object[fieldName]
+});


### PR DESCRIPTION
Additionally filed 'Required documents was fixed. For example: Tax Aid organization from healthleads provider had too much text for a standard field.